### PR TITLE
Make the new library backward-compatible

### DIFF
--- a/lib/nkeys.ex
+++ b/lib/nkeys.ex
@@ -1,0 +1,18 @@
+defmodule NKEYS do
+  alias NKEYS.Keypair
+
+  @doc deprecated: "Please use the `NKEYS.Keypair.from_seed/1` function instead"
+  def from_seed(seed) when is_binary(seed) do
+    Keypair.from_seed(seed)
+  end
+
+  @doc deprecated: "Please use the `NKEYS.Keypair.public_key/1` function instead"
+  def public_nkey(keypair) do
+    Keypair.public_key(keypair)
+  end
+
+  @doc deprecated: "Please use the `NKEYS.Keypair.sign/2` function instead"
+  def sign(keypair, message) do
+    Keypair.sign(keypair, message)
+  end
+end

--- a/lib/nkeys/crc.ex
+++ b/lib/nkeys/crc.ex
@@ -1,4 +1,4 @@
-defmodule Nkeys.CRC do
+defmodule NKEYS.CRC do
   @moduledoc false
 
   import Bitwise,

--- a/lib/nkeys/keypair.ex
+++ b/lib/nkeys/keypair.ex
@@ -1,4 +1,4 @@
-defmodule Nkeys.Keypair do
+defmodule NKEYS.Keypair do
   @moduledoc """
   Contains functions for creating, manipulating, and interacting with key pairs
   """
@@ -118,7 +118,7 @@ defmodule Nkeys.Keypair do
   """
   def public_key(%__MODULE__{public_key: public_key, prefix: prefix}) do
     with_prefix = <<prefix::size(5), 0::size(3), public_key::binary>>
-    crc = Nkeys.CRC.compute(with_prefix)
+    crc = NKEYS.CRC.compute(with_prefix)
     Base.encode32(<<with_prefix::binary, crc::size(16)-little>>, padding: false)
   end
 
@@ -178,7 +178,7 @@ defmodule Nkeys.Keypair do
   @doc false
   def encode(prefix, src) do
     raw = [prefix | src] |> :binary.list_to_bin()
-    crc = Nkeys.CRC.compute(raw)
+    crc = NKEYS.CRC.compute(raw)
     new = raw <> <<crc::little-16>>
     Base.encode32(new, padding: false)
   end
@@ -189,7 +189,7 @@ defmodule Nkeys.Keypair do
     b2 = (prefix &&& 31) <<< 3
 
     raw = [b1, b2 | src] |> :binary.list_to_bin()
-    crc = Nkeys.CRC.compute(raw)
+    crc = NKEYS.CRC.compute(raw)
     new = raw <> <<crc::little-16>>
     Base.encode32(new, padding: false)
   end
@@ -200,7 +200,7 @@ defmodule Nkeys.Keypair do
          n <- byte_size(raw) do
       <<prefix::binary-size(1), in_stripped::binary-size(n - 3), crc::little-16>> = raw
 
-      if Nkeys.CRC.compute(in_stripped) != crc do
+      if NKEYS.CRC.compute(in_stripped) != crc do
         {:error, :bad_crc}
       else
         {:ok, in_stripped, prefix}

--- a/lib/nkeys/xkeys.ex
+++ b/lib/nkeys/xkeys.ex
@@ -1,4 +1,4 @@
-defmodule Nkeys.Xkeys do
+defmodule NKEYS.Xkeys do
   @moduledoc """
   Contains functions for using curve (X) keys for sending and receiving encrypted
   messages

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Nkeys.MixProject do
       source_url: @source_url,
       extras: [
         "README.md"
-      ],
+      ]
     ]
   end
 

--- a/test/crc_test.exs
+++ b/test/crc_test.exs
@@ -1,6 +1,6 @@
-defmodule Nkeys.CRCTest do
+defmodule NKEYS.CRCTest do
   use ExUnit.Case, async: true
-  import Nkeys.CRC, only: [compute: 1]
+  import NKEYS.CRC, only: [compute: 1]
 
   test "computes the CRC of an empty string as 0x0000" do
     assert compute("") == 0x0000

--- a/test/keypair_test.exs
+++ b/test/keypair_test.exs
@@ -1,14 +1,13 @@
-defmodule Nkeys.KeypairTest do
+defmodule NKEYS.KeypairTest do
   use ExUnit.Case
 
   describe "decode/1" do
     test "properly decodes a key used by golang tests" do
-      seed = "SAAOEFWEJFOR67CV7CLVKGEDVFOPU4EHDY4BZTCCCK3UFVISYBNOQLB4QQ"
       public = "AACKDD7DWAJM2K76WMDHTHTIN2WZLKA7MGSLNHIHSZ3ZRSEBZG6GWECF"
 
-      {:ok, decoded, _} = Nkeys.Keypair.decode(public)
+      {:ok, decoded, _} = NKEYS.Keypair.decode(public)
       # 0 is the account prefix
-      encoded = Nkeys.Keypair.encode(0, decoded)
+      encoded = NKEYS.Keypair.encode(0, decoded)
       assert encoded == public
     end
   end
@@ -16,7 +15,7 @@ defmodule Nkeys.KeypairTest do
   describe "from_seed/1" do
     test "creates a struct from a valid seed" do
       assert {:ok, nkey} =
-               Nkeys.Keypair.from_seed(
+               NKEYS.Keypair.from_seed(
                  "SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
                )
 
@@ -26,20 +25,20 @@ defmodule Nkeys.KeypairTest do
 
     test "should raise error when seed has bad padding" do
       assert {:error, :invalid_seed} =
-               Nkeys.Keypair.from_seed(
+               NKEYS.Keypair.from_seed(
                  "UAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
                )
     end
 
     test "should raise error with invalid seeds" do
       assert {:error, :invalid_seed} =
-               Nkeys.Keypair.from_seed(
+               NKEYS.Keypair.from_seed(
                  "AUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
                )
 
-      assert {:error, :invalid_seed} = Nkeys.Keypair.from_seed("")
+      assert {:error, :invalid_seed} = NKEYS.Keypair.from_seed("")
 
-      assert {:error, :invalid_seed} = Nkeys.Keypair.from_seed(" ")
+      assert {:error, :invalid_seed} = NKEYS.Keypair.from_seed(" ")
     end
 
     test "should validate prefix bytes" do
@@ -51,7 +50,7 @@ defmodule Nkeys.KeypairTest do
       ]
 
       Enum.each(seeds, fn seed ->
-        assert {:ok, _nkey} = Nkeys.Keypair.from_seed(seed)
+        assert {:ok, _nkey} = NKEYS.Keypair.from_seed(seed)
       end)
 
       invalid_seeds = [
@@ -60,7 +59,7 @@ defmodule Nkeys.KeypairTest do
       ]
 
       Enum.each(invalid_seeds, fn seed ->
-        assert {:error, :invalid_seed} = Nkeys.Keypair.from_seed(seed)
+        assert {:error, :invalid_seed} = NKEYS.Keypair.from_seed(seed)
       end)
 
       invalid_seeds = [
@@ -69,7 +68,7 @@ defmodule Nkeys.KeypairTest do
       ]
 
       Enum.each(invalid_seeds, fn seed ->
-        assert {:error, :invalid_seed} = Nkeys.Keypair.from_seed(seed)
+        assert {:error, :invalid_seed} = NKEYS.Keypair.from_seed(seed)
       end)
     end
   end
@@ -79,8 +78,8 @@ defmodule Nkeys.KeypairTest do
 
     test "from_seed" do
       nonce = "PXoWU7zWAMt75FY"
-      {:ok, nkeys} = Nkeys.Keypair.from_seed(@seed)
-      signed_nonce = Nkeys.Keypair.sign(nkeys, nonce)
+      {:ok, nkeys} = NKEYS.Keypair.from_seed(@seed)
+      signed_nonce = NKEYS.Keypair.sign(nkeys, nonce)
       encoded_signed_nonce = Base.encode64(signed_nonce)
 
       assert encoded_signed_nonce ==
@@ -89,8 +88,8 @@ defmodule Nkeys.KeypairTest do
 
     test "a second nonce" do
       nonce = "iBFByN3zQjAT7dQ"
-      {:ok, nkeys} = Nkeys.Keypair.from_seed(@seed)
-      signed_nonce = Nkeys.Keypair.sign(nkeys, nonce)
+      {:ok, nkeys} = NKEYS.Keypair.from_seed(@seed)
+      signed_nonce = NKEYS.Keypair.sign(nkeys, nonce)
       encoded_signed_nonce = Base.url_encode64(signed_nonce)
 
       assert encoded_signed_nonce ==
@@ -99,9 +98,9 @@ defmodule Nkeys.KeypairTest do
   end
 
   test "creating a public nkey" do
-    {:ok, nkeys} = Nkeys.Keypair.from_seed(@seed)
+    {:ok, nkeys} = NKEYS.Keypair.from_seed(@seed)
 
-    assert Nkeys.Keypair.public_key(nkeys) ==
+    assert NKEYS.Keypair.public_key(nkeys) ==
              "UCK5N7N66OBOINFXAYC2ACJQYFSOD4VYNU6APEJTAVFZB2SVHLKGEW7L"
   end
 end

--- a/test/nkeys_test.exs
+++ b/test/nkeys_test.exs
@@ -1,4 +1,93 @@
-defmodule NkeysTest do
+defmodule NKEYSTest do
   use ExUnit.Case
-  doctest Nkeys
+  doctest NKEYS
+
+  ## Deprecated
+  # All of the tests below are for backward compatibility purposes
+  # It keeps the original public interface of the NKEYS module unchanged
+  # so client libraries can easily upgrade with us. We'll drop these
+  # functions in a future version of this library
+  describe "from_seed/1" do
+    test "creates a struct from a valid seed" do
+      assert {:ok, nkey} =
+               NKEYS.from_seed("SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU")
+
+      assert nkey.private_key != nil
+      assert nkey.public_key != nil
+    end
+
+    test "should raise error when seed has bad padding" do
+      assert {:error, :invalid_seed} =
+               NKEYS.from_seed("UAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU")
+    end
+
+    test "should raise error with invalid seeds" do
+      assert {:error, :invalid_seed} =
+               NKEYS.from_seed("AUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU")
+
+      assert {:error, :invalid_seed} = NKEYS.from_seed("")
+
+      assert {:error, :invalid_seed} = NKEYS.from_seed(" ")
+    end
+
+    test "should validate prefix bytes" do
+      seeds = [
+        "SNAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU",
+        "SCAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU",
+        "SOAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU",
+        "SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
+      ]
+
+      Enum.each(seeds, fn seed ->
+        assert {:ok, _nkey} = NKEYS.from_seed(seed)
+      end)
+
+      invalid_seeds = [
+        "SDAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU",
+        "SBAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
+      ]
+
+      Enum.each(invalid_seeds, fn seed ->
+        assert {:error, :invalid_seed} = NKEYS.from_seed(seed)
+      end)
+
+      invalid_seeds = [
+        "PWAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU",
+        "PMAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
+      ]
+
+      Enum.each(invalid_seeds, fn seed ->
+        assert {:error, :invalid_seed} = NKEYS.from_seed(seed)
+      end)
+    end
+  end
+
+  describe "sign/2" do
+    @seed "SUAMLK2ZNL35WSMW37E7UD4VZ7ELPKW7DHC3BWBSD2GCZ7IUQQXZIORRBU"
+
+    test "from_seed" do
+      nonce = "PXoWU7zWAMt75FY"
+      {:ok, nkeys} = NKEYS.from_seed(@seed)
+      signed_nonce = NKEYS.sign(nkeys, nonce)
+      encoded_signed_nonce = Base.encode64(signed_nonce)
+
+      assert encoded_signed_nonce ==
+               "ZaAiVDgB5CeYoXoQ7cBCmq+ZllzUnGUoDVb8C7PilWvCs8XKfUchAUhz2P4BYAF++Dg3w05CqyQFRDiGL6LrDw=="
+    end
+
+    test "a second nonce" do
+      nonce = "iBFByN3zQjAT7dQ"
+      {:ok, nkeys} = NKEYS.from_seed(@seed)
+      signed_nonce = NKEYS.sign(nkeys, nonce)
+      encoded_signed_nonce = Base.url_encode64(signed_nonce)
+
+      assert encoded_signed_nonce ==
+               "kagPGrixaWS5yuHqw9nTQrda1Q376fK3fRCGtYdF4_w2aSk-4O7Ca0JM0qvzm69HH6MoMps2yF6Q0Qs830JZCA=="
+    end
+  end
+
+  test "creating a public nkey" do
+    {:ok, nkeys} = NKEYS.from_seed(@seed)
+    assert NKEYS.public_nkey(nkeys) == "UCK5N7N66OBOINFXAYC2ACJQYFSOD4VYNU6APEJTAVFZB2SVHLKGEW7L"
+  end
 end

--- a/test/xkeys_test.exs
+++ b/test/xkeys_test.exs
@@ -1,15 +1,15 @@
-defmodule Nkeys.XkeysTest do
-  alias Nkeys.Keypair
+defmodule NKEYS.XkeysTest do
+  alias NKEYS.{Keypair, Xkeys}
   use ExUnit.Case
 
   describe "seal and unseal" do
     test "should round trip with no loss" do
       input = "this is top secret"
-      alice = Nkeys.Keypair.new_user()
-      bob = Nkeys.Keypair.new_user()
+      alice = Keypair.new_user()
+      bob = Keypair.new_user()
 
-      sealed_data = Nkeys.Xkeys.seal(input, bob.public_key, alice.private_key)
-      {:ok, unsealed_data} = Nkeys.Xkeys.open(sealed_data, alice.private_key, bob.public_key)
+      sealed_data = Xkeys.seal(input, bob.public_key, alice.private_key)
+      {:ok, unsealed_data} = Xkeys.open(sealed_data, alice.private_key, bob.public_key)
 
       assert "this is top secret" == unsealed_data
     end


### PR DESCRIPTION
* keep the NKEYS namespace with the same casing
* provide soft-deprecated functions in the NKEYS module
* carryover tests from the previous version to ensure we maintain compatibility until we're ready to drop it