### PR TITLE
Bad pattern match in NKEYS.Xkeys.open/3

### DIFF
--- a/lib/nkeys/xkeys.ex
+++ b/lib/nkeys/xkeys.ex
@@ -33,8 +33,8 @@ defmodule NKEYS.Xkeys do
     <<_version::binary-size(4), nonce::binary-size(@nonce_size), message::binary>> = input
 
     case Kcl.unbox(message, nonce, our_secret, their_public) do
+      {:error, _reason} -> :error
       {binary, _} -> {:ok, binary}
-      :error -> :error
     end
   end
 end


### PR DESCRIPTION
Found by Elixir 1.18

```elixir
Compiling 4 files (.ex)
    warning: the following clause will never match:

        :error

    because it attempts to match on the result of:

        Kcl.unbox(message, nonce, our_secret, their_public)

    which has type:

        dynamic({:error, binary()} or {:error or binary(), term()})

    typing violation found at:
    │
 37 │       :error -> :error
    │       ~~~~~~~~~~~~~~~~
    │
    └─ lib/nkeys/xkeys.ex:37: NKEYS.Xkeys.open/3
```